### PR TITLE
Update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^0.14.0",
-    "cq-prolyfill": "^0.2.4"
+    "react": "^0.14.0 || ^15.0.0",
+    "cq-prolyfill": "^0.3.0"
   },
   "devDependencies": {
     "nwb": "~0.4.1",
-    "cq-prolyfill": "^0.2.4",
-    "react": "~0.14.0",
-    "react-dom": "~0.14.0"
+    "cq-prolyfill": "^0.3.0",
+    "react": "~0.14.0 || ^15.0.0",
+    "react-dom": "~0.14.0 || ^15.0.0"
   },
   "author": "Vince Speelman",
   "homepage": "",


### PR DESCRIPTION
I use the latest stable versions of React and cq-prolyfill in my codebase and I get the following error on most npm actions:

``` shell
my-project@1.0.0 /path/to/my-project
├── UNMET PEER DEPENDENCY cq-prolyfill@0.3.2
└── UNMET PEER DEPENDENCY react@15.3.1
```

It doesn't break anything, but it'd be nice to not get glaring red messages 😄 
